### PR TITLE
Corrected "compatible core version"

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "author" : "Spetzel",
   "version": "0.6.3",
   "minimumCoreVersion": "0.6.5",
-  "compatibleCoreVersion": "9.238",
+  "compatibleCoreVersion": "9",
   "languages": [
     {
       "lang": "en",


### PR DESCRIPTION
In foundry V9 the build number does not have to be specified. After this change the "compatibility risk" warning disappears in Foundry V9